### PR TITLE
feat: add href links for donations and email

### DIFF
--- a/partials/modals/modal-about.html
+++ b/partials/modals/modal-about.html
@@ -28,13 +28,15 @@
       </div>
     </div>
     <div class="modal-action">
-      <button class="btn btn-outline">
-        <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" viewBox="0 0 24 24">
-          <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                d="M19.5 12.572L12 20l-7.5-7.428A5 5 0 1 1 12 6.006a5 5 0 1 1 7.5 6.572"/>
-        </svg>
+      <a href="https://ko-fi.com/carlosrr" target="_blank">
+        <button class="btn btn-outline">
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" viewBox="0 0 24 24">
+            <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                  d="M19.5 12.572L12 20l-7.5-7.428A5 5 0 1 1 12 6.006a5 5 0 1 1 7.5 6.572"/>
+          </svg>
         <span>Donations</span>
-      </button>
+        </button>
+      </a>
       <form method="dialog">
         <button class="btn btn-secondary">I understand!</button>
       </form>

--- a/partials/sections/socials.html
+++ b/partials/sections/socials.html
@@ -1,13 +1,13 @@
 <section class="dv-container p-6">
   <ul class="flex justify-center">
     <li>
-      <a class="btn btn-sm md:btn-md btn-ghost" href="">
+      <a class="btn btn-sm md:btn-md btn-ghost" href="https://ko-fi.com/carlosrr" target="_blank">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" viewBox="0 0 24 24">
           <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                 d="M19.5 12.572L12 20l-7.5-7.428A5 5 0 1 1 12 6.006a5 5 0 1 1 7.5 6.572"/>
         </svg>
       </a>
-      <a class="btn btn-sm md:btn-md btn-ghost" href="">
+      <a class="btn btn-sm md:btn-md btn-ghost" href="mailto:contact@crr.codes" target="_blank">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" viewBox="0 0 24 24">
           <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
             <path d="M3 7a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>
@@ -15,13 +15,13 @@
           </g>
         </svg>
       </a>
-      <a class="btn btn-sm md:btn-md btn-ghost" href="">
+      <a class="btn btn-sm md:btn-md btn-ghost" href="" target="_blank">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" viewBox="0 0 24 24">
           <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                 d="M9 19c-4.3 1.4-4.3-2.5-6-3m12 5v-3.5c0-1 .1-1.4-.5-2c2.8-.3 5.5-1.4 5.5-6a4.6 4.6 0 0 0-1.3-3.2a4.2 4.2 0 0 0-.1-3.2s-1.1-.3-3.5 1.3a12.3 12.3 0 0 0-6.2 0C6.5 2.8 5.4 3.1 5.4 3.1a4.2 4.2 0 0 0-.1 3.2A4.6 4.6 0 0 0 4 9.5c0 4.6 2.7 5.7 5.5 6c-.6.6-.6 1.2-.5 2V21"/>
         </svg>
       </a>
-      <a class="btn btn-sm md:btn-md btn-ghost" href="">
+      <a class="btn btn-sm md:btn-md btn-ghost" href="" target="_blank">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" viewBox="0 0 24 24">
           <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                 d="m4 4l11.733 16H20L8.267 4zm0 16l6.768-6.768m2.46-2.46L20 4"/>


### PR DESCRIPTION
- Added an href link to the heart and `Donations` button that opens the `ko-fi.com/carlosrr` URL in a new tab
- Added an href link to the email button at socials that opens the `mailto:contact@crr.codes URL`
- Used the `target=_blank` attribute to open the links in a new tab

resolves first-half of #5  